### PR TITLE
Feature: Skip if file exists

### DIFF
--- a/PSXPackager/Options.cs
+++ b/PSXPackager/Options.cs
@@ -28,8 +28,8 @@ namespace PSXPackager
         [Option('x', Required = false, HelpText = "If this option is present, will overwrite a file if it exists, otherwise will ask confirmation.")]
         public bool OverwriteIfExists { get; set; }
 
-        //[Option('s', "skip", Required = false, HelpText = "If this optioe n is present, will skip existing files.")]
-        //public bool SkipIfExists { get; set; }
+        [Option('s', "skip", Required = false, HelpText = "If this option is present, will skip existing files.")]
+        public bool SkipIfExists { get; set; }
 
         [Option('f', "format", Required = false, Default = "%FILENAME%", HelpText = "Specify the filename format e.g. [%GAMEID%] [%MAINGAMEID%] %TITLE% (%REGION%) or %FILENAME%")]
         public string FileNameFormat { get; set; }

--- a/PSXPackager/ProcessOptions.cs
+++ b/PSXPackager/ProcessOptions.cs
@@ -9,6 +9,7 @@ namespace PSXPackager
         public string TempPath { get; set; }
         public IEnumerable<int> Discs { get; set; }
         public bool CheckIfFileExists { get; set; }
+        public bool SkipIfFileExists { get; set; }
         public int CompressionLevel { get; set; }
         public string FileNameFormat{ get; set; }
         public bool Log { get; set; }

--- a/PSXPackager/Processing.cs
+++ b/PSXPackager/Processing.cs
@@ -475,6 +475,7 @@ namespace PSXPackager
                 BasePbp = Path.Combine(appPath, "Resources", "BASE.PBP"),
                 CompressionLevel = processOptions.CompressionLevel,
                 CheckIfFileExists = processOptions.CheckIfFileExists,
+                SkipIfFileExists = processOptions.SkipIfFileExists,
                 FileNameFormat = processOptions.FileNameFormat,
             };
 
@@ -544,6 +545,7 @@ namespace PSXPackager
                 BasePbp = Path.Combine(appPath, "Resources", "BASE.PBP"),
                 CompressionLevel = processOptions.CompressionLevel,
                 CheckIfFileExists = processOptions.CheckIfFileExists,
+                SkipIfFileExists = processOptions.SkipIfFileExists,
                 FileNameFormat = processOptions.FileNameFormat,
             };
 
@@ -571,6 +573,7 @@ namespace PSXPackager
                 Discs = processOptions.Discs,
                 CreateCuesheet = true,
                 CheckIfFileExists = processOptions.CheckIfFileExists,
+                SkipIfFileExists = processOptions.SkipIfFileExists,
                 FileNameFormat = processOptions.FileNameFormat,
                 GetGameInfo = (gameId) =>
                 {

--- a/PSXPackager/Program.cs
+++ b/PSXPackager/Program.cs
@@ -26,7 +26,7 @@ namespace PSXPackager
 
         static void Main(string[] args)
         {
-            SevenZip.SevenZipBase.SetLibraryPath("x64/7z.dll");
+            SevenZip.SevenZipBase.SetLibraryPath(Path.Combine(ApplicationInfo.AppPath, $"{(System.Environment.Is64BitOperatingSystem ? "x64" : "x86")}/7z.dll"));
 
             _cancellationTokenSource = new CancellationTokenSource();
 
@@ -136,6 +136,7 @@ namespace PSXPackager
                          TempPath = tempPath,
                          Discs = discs,
                          CheckIfFileExists = !o.OverwriteIfExists,
+                         SkipIfFileExists = o.SkipIfExists,
                          FileNameFormat = o.FileNameFormat,
                          CompressionLevel = o.CompressionLevel,
                          Verbosity = o.Verbosity,

--- a/Popstation/ConvertOptions.cs
+++ b/Popstation/ConvertOptions.cs
@@ -22,6 +22,8 @@ namespace Popstation
         public List<DiscInfo> DiscInfos { get; set; }
         public List<PatchData> Patches { get; set; }
         public bool CheckIfFileExists { get; set; }
+
+        public bool SkipIfFileExists { get; set; }
         public string FileNameFormat { get; set; }
         public string MainGameRegion { get; set; }
     };

--- a/Popstation/ExtractOptions.cs
+++ b/Popstation/ExtractOptions.cs
@@ -6,6 +6,7 @@ namespace Popstation
     public interface ICheckIfFileExists
     {
         bool CheckIfFileExists { get; set; }
+        bool SkipIfFileExists { get; set; }
     }
 
     public class GameInfo
@@ -25,6 +26,7 @@ namespace Popstation
         public bool CreatePlaylist { get; set; }
         public IEnumerable<int> Discs { get; set; }
         public bool CheckIfFileExists { get; set; }
+        public bool SkipIfFileExists { get; set; }
         public string OutputPath { get; set; }
         public Func<string, GameInfo> GetGameInfo { get; set; }
         public string FileNameFormat { get; set; }

--- a/Popstation/Popstation.Extract.cs
+++ b/Popstation/Popstation.Extract.cs
@@ -149,7 +149,9 @@ namespace Popstation
 
         private bool ContinueIfFileExists(ICheckIfFileExists options, string path)
         {
-            if (!options.CheckIfFileExists || !File.Exists(path)) return true;
+            var fileExists = File.Exists(path);
+            if (options.SkipIfFileExists && fileExists) return false;
+            if (!options.CheckIfFileExists || !fileExists) return true;
             var response = ActionIfFileExists(path);
 
             switch (response)

--- a/Popstation/Popstation.csproj
+++ b/Popstation/Popstation.csproj
@@ -16,40 +16,39 @@
     <PackageReference Include="SharpZipLib" Version="1.2.0" />
   </ItemGroup>
 
-
   <ItemGroup>
     <None Update="Resources\back.png">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="Resources\BASE.PBP">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="Resources\DATA.PSP">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="Resources\gameInfo.db">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="Resources\ICON0.PNG">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="Resources\icon_back.png">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="Resources\icon_back_80x80.png">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="Resources\KEYS.BIN">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="Resources\no_icon0.png">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="Resources\PIC0.PNG">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="Resources\PIC1.PNG">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
 


### PR DESCRIPTION
This PR implements the commented out `--skip/-s` flag. I also included a fix to make it check for the `7z.dll` library relative to the executable in the same way the resources do.