### PR TITLE
Don't remove file extension when input path is directory

### DIFF
--- a/Popstation/Popstation.cs
+++ b/Popstation/Popstation.cs
@@ -39,8 +39,14 @@ namespace Popstation
             var code = convertInfo.MainGameID;
             var region = convertInfo.MainGameRegion;
 
+            var originalFilename = convertInfo.OriginalFilename;
+            if (Directory.Exists(convertInfo.OriginalPath)) 
+            {
+                originalFilename += ".dir";
+            }
+
             var outputFilename = GetFilename(convertInfo.FileNameFormat,
-                convertInfo.OriginalFilename,
+                originalFilename,
                 code,
                 code,
                 title,


### PR DESCRIPTION
Here is `Foo Ver.Bar (USA)` directory.

```
Foo Ver.Bar (USA)
  - Foo Ver.Bar (USA) (Track 01).bin
  - Foo Ver.Bar (USA) (Track 02).bin
  - Foo Ver.Bar (USA) (Track 03).bin
  - Foo Ver.Bar (USA) (Track 04).bin
  - Foo Ver.Bar (USA).cue
```

Running

```
PSXPackager -o /path/to/PBP  -i /path/to/Foo\ Ver\.Bar\ \(USA\)
```

Rsult is stored to `/path/to/PBP/Foo Ver.pbp`. But it should be `/path/to/PBP/Foo Ver.Bar (USA).pbp`


This fix makes it so.