### PR TITLE
Add Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,27 @@
+.PHONY:	all build clean
+
+.PHONY:	build-linux-x64 build-osx-x64
+.PHONY:	clean-linux-x64 clean-osx-x64
+
+all:	build
+
+build:
+	$(MAKE) build-linux-x64
+	$(MAKE) build-osx-x64
+
+build-linux-x64:
+	dotnet publish ./PSXPackager/PSXPackager-linux.csproj -c Release -r linux-x64 -o ./build/linux-x64 /p:DebugType=None /p:DebugSymbols=false
+	cp README.MD ./build/linux-x64
+
+build-osx-x64:
+	dotnet publish ./PSXPackager/PSXPackager-linux.csproj -c Release -r osx-x64 -o ./build/osx-x64 /p:DebugType=None /p:DebugSymbols=false
+	cp README.MD ./build/osx-x64
+
+clean:	clean-linux-x64 clean-osx-x64
+
+clean-linux-x64:
+	rm -rf ./build/linux-x64
+
+clean-osx-x64:
+	rm -rf ./build/osx-x64
+

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,28 @@
 .PHONY:	all build clean
+all:
+	$(MAKE) clean
+	$(MAKE) build
 
-.PHONY:	build-linux-x64 build-osx-x64
-.PHONY:	clean-linux-x64 clean-osx-x64
-
-all:	build
-
+.PHONY:	build-gui-win-x64 build-win-x64 build-linux-x64 build-osx-x64
 build:
+	$(MAKE) build-gui-win-x64
+	$(MAKE) build-win-x64
 	$(MAKE) build-linux-x64
 	$(MAKE) build-osx-x64
+
+.PHONY:	clean-gui-win-x64 clean-win-x64 clean-linux-x64 clean-osx-x64
+clean:	clean-gui-win-x64 clean-win-x64 clean-linux-x64 clean-osx-x64
+
+
+build-gui-win-x64:
+	dotnet publish ./PSXPackagerGUI/PSXPackagerGUI.csproj -c Release -r win-x64 -o ./build/PsxPackagerGUI --no-self-contained /p:PublishSingleFile=true /p:PublishReadyToRun=false /p:DefineConstants="SEVENZIP" /p:DebugType=None /p:DebugSymbols=false /p:EnableWindowsTargeting=true
+	cp -a ./libs ./build/PsxPackagerGUI
+	cp README.MD ./build/PSXPackagerGUI
+
+build-win-x64:
+	dotnet publish ./PSXPackager/PSXPackager-windows.csproj -c Release -r win-x64 -o ./build/win-x64 /p:DefineConstants="SEVENZIP" /p:DebugType=None /p:DebugSymbols=false /p:EnableWindowsTargeting=true
+	cp -a ./libs ./build/win-x64
+	cp README.MD ./build/win-x64
 
 build-linux-x64:
 	dotnet publish ./PSXPackager/PSXPackager-linux.csproj -c Release -r linux-x64 -o ./build/linux-x64 /p:DebugType=None /p:DebugSymbols=false
@@ -17,7 +32,12 @@ build-osx-x64:
 	dotnet publish ./PSXPackager/PSXPackager-linux.csproj -c Release -r osx-x64 -o ./build/osx-x64 /p:DebugType=None /p:DebugSymbols=false
 	cp README.MD ./build/osx-x64
 
-clean:	clean-linux-x64 clean-osx-x64
+
+clean-gui-win-x64:
+	rm -rf ./build/PsxPackagerGUI
+
+clean-win-x64:
+	rm -rf ./build/win-x64
 
 clean-linux-x64:
 	rm -rf ./build/linux-x64

--- a/build-all.cmd
+++ b/build-all.cmd
@@ -1,4 +1,3 @@
 call build-gui-win-x64.cmd
 call build-win-x64.cmd
-call build-linux-x64.cmd
-call build-osx-x64.cmd
+

--- a/build-linux-x64.cmd
+++ b/build-linux-x64.cmd
@@ -1,3 +1,0 @@
-del /s /q .\build\linux-x64
-dotnet publish .\PSXPackager\PSXPackager-linux.csproj -c Release -r linux-x64 -o .\build\linux-x64 /p:DebugType=None /p:DebugSymbols=false
-copy README.MD .\build\linux-x64

--- a/build-osx-x64.cmd
+++ b/build-osx-x64.cmd
@@ -1,3 +1,0 @@
-del /s /q .\build\osx-x64
-dotnet publish .\PSXPackager\PSXPackager-linux.csproj -c Release -r osx-x64 -o .\build\osx-x64 /p:DebugType=None /p:DebugSymbols=false
-copy README.MD .\build\osx-x64

--- a/build-osx-x64.sh
+++ b/build-osx-x64.sh
@@ -1,3 +1,0 @@
-rm -rf ./build/osx-x64
-dotnet publish ./PSXPackager/PSXPackager-linux.csproj -c Release -r osx-x64 -o ./build/osx-x64 /p:DebugType=None /p:DebugSymbols=false
-cp README.MD ./build/osx-x64


### PR DESCRIPTION
Usually linux and osx developers use Makefile for simple builds.

#### Build all binaries

```
$ make build
```

#### Build only linux-x64 binary

```
$ make build-linux-x64
```


#### Build only osx-x64 binary

```
$ make build-osx-x64
```

#### Cleanup Builds
```
$ make clean
```

#### Cleanup Builds and Build all binaries

```
$ make
```
