### PR TITLE
Fix for CS0219 and CS0168 Warnings

### DIFF
--- a/Popstation.Database/GameDB.cs
+++ b/Popstation.Database/GameDB.cs
@@ -55,14 +55,11 @@ namespace Popstation.Database
                 //        break;
                 //    }
                 //}
-                var syscnfFound = false;
 
                 foreach (var file in cdReader.GetFiles("\\"))
                 {
                     var filename = file.Substring(1, file.LastIndexOf(";") - 1);
                     if (filename != "SYSTEM.CNF") continue;
-
-                    syscnfFound = true;
 
                     using (var datastream = cdReader.OpenFile(file, FileMode.Open))
                     {

--- a/Popstation/Pbp/MultiDiscPbpWriter.cs
+++ b/Popstation/Pbp/MultiDiscPbpWriter.cs
@@ -13,8 +13,6 @@ namespace Popstation.Pbp
 
         public override void WritePSAR(Stream outputStream, uint psarOffset, CancellationToken cancellationToken)
         {
-            uint totSize;
-
             var title = convertInfo.MainGameTitle;
             var code = convertInfo.MainGameID;
 
@@ -66,7 +64,6 @@ namespace Popstation.Pbp
             for (var discNo = 0; discNo < convertInfo.DiscInfos.Count; discNo++)
             {
                 var disc = convertInfo.DiscInfos[discNo];
-                uint curSize = 0;
 
                 offset = (uint)outputStream.Position;
 


### PR DESCRIPTION
Fix for below CS0219 Warnings and CS0168 Warnigs.
```
/Users/takano32/GitHub/PSXPackager/Popstation.Database/GameDB.cs(58,21): warning CS0219: The variable 'syscnfFound' is assigned but its value is never used [/Users/takano32/GitHub/PSXPackager/Popstation.Database/Popstation.Database.csproj::TargetFramework=netstandard2.0]
/Users/takano32/GitHub/PSXPackager/Popstation/Pbp/MultiDiscPbpWriter.cs(69,22): warning CS0219: The variable 'curSize' is assigned but its value is never used [/Users/takano32/GitHub/PSXPackager/Popstation/Popstation.csproj::TargetFramework=netstandard2.0]
/Users/takano32/GitHub/PSXPackager/Popstation/Pbp/MultiDiscPbpWriter.cs(16,18): warning CS0168: The variable 'totSize' is declared but never used [/Users/takano32/GitHub/PSXPackager/Popstation/Popstation.csproj::TargetFramework=netstandard2.0]
```

