### PR TITLE
Fix PSXPackagerGUI Release path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,8 @@ clean:	clean-gui-win-x64 clean-win-x64 clean-linux-x64 clean-osx-x64
 
 
 build-gui-win-x64:
-	dotnet publish ./PSXPackagerGUI/PSXPackagerGUI.csproj -c Release -r win-x64 -o ./build/PsxPackagerGUI --no-self-contained /p:PublishSingleFile=true /p:PublishReadyToRun=false /p:DefineConstants="SEVENZIP" /p:DebugType=None /p:DebugSymbols=false /p:EnableWindowsTargeting=true
-	cp -a ./libs ./build/PsxPackagerGUI
+	dotnet publish ./PSXPackagerGUI/PSXPackagerGUI.csproj -c Release --no-self-contained -r win-x64 -o ./build/PSXPackagerGUI /p:PublishSingleFile=true /p:PublishReadyToRun=false /p:DefineConstants="SEVENZIP" /p:DebugType=None /p:DebugSymbols=false /p:EnableWindowsTargeting=true
+	cp -a ./libs ./build/PSXPackagerGUI
 	cp README.MD ./build/PSXPackagerGUI
 
 build-win-x64:


### PR DESCRIPTION
Sorry for trivial fix.

I built binaries in Linux and got something strange file. 

That's `README.MD`...

```
$ make
$ ls build
linux-x64  osx-x64  PsxPackagerGUI  PSXPackagerGUI  win-x64
$ file build/PsxPackagerGUI
build/PsxPackagerGUI: directory
$ file build/PSXPackagerGUI 
build/PSXPackagerGUI: UTF-8 Unicode (with BOM) text
$ head -3 build/PSXPackagerGUI 
﻿# PSXPackager

PSXPackager is a port of the `popstation-md` C source to C#.
```

This fix, set Release directory as `PSXPackagerGUI` and  working **case sensitive** `copy`  command in **case sensitive** file system without problem.