### PR TITLE
Fix return values of functions having cancel request

### DIFF
--- a/Popstation/Popstation.Repack.cs
+++ b/Popstation/Popstation.Repack.cs
@@ -59,7 +59,7 @@ namespace Popstation
                     Directory.Delete(path, true);
                 }
 
-                return cancellationToken.IsCancellationRequested == false;
+                return !cancellationToken.IsCancellationRequested;
 
             }
         }

--- a/Popstation/Popstation.Repack.cs
+++ b/Popstation/Popstation.Repack.cs
@@ -33,13 +33,13 @@ namespace Popstation
                     var region = options.MainGameRegion;
 
                     var outputFilename = GetFilename(options.FileNameFormat,
-                        options.OriginalFilename,
-                        code,
-                        code,
-                        title,
-                        title,
-                        region
-                        );
+                            options.OriginalFilename,
+                            code,
+                            code,
+                            title,
+                            title,
+                            region
+                            );
 
                     var outputPath = Path.Combine(directory, $"{outputFilename}{ext}");
 

--- a/Popstation/Popstation.Repack.cs
+++ b/Popstation/Popstation.Repack.cs
@@ -59,7 +59,7 @@ namespace Popstation
                     Directory.Delete(path, true);
                 }
 
-                return cancellationToken.IsCancellationRequested;
+                return cancellationToken.IsCancellationRequested == false;
 
             }
         }

--- a/Popstation/Popstation.cs
+++ b/Popstation/Popstation.cs
@@ -68,7 +68,7 @@ namespace Popstation
                 writer.Write(outputStream, cancellationToken);
             }
 
-            return cancellationToken.IsCancellationRequested == false;
+            return !cancellationToken.IsCancellationRequested;
         }
 
     }

--- a/Popstation/Popstation.cs
+++ b/Popstation/Popstation.cs
@@ -40,7 +40,7 @@ namespace Popstation
             var region = convertInfo.MainGameRegion;
 
             var originalFilename = convertInfo.OriginalFilename;
-            if (Directory.Exists(convertInfo.OriginalPath)) 
+            if (Directory.Exists(convertInfo.OriginalPath))
             {
                 originalFilename += ".dir";
             }
@@ -68,7 +68,7 @@ namespace Popstation
                 writer.Write(outputStream, cancellationToken);
             }
 
-            return cancellationToken.IsCancellationRequested;
+            return cancellationToken.IsCancellationRequested == false;
         }
 
     }


### PR DESCRIPTION
The style of processing functions is to return true on success, but some functions return true on cancellation and false when there is no cancellation, which is the opposite of the overall style.

This fix returns false when a cancellation is made and true when no cancellation is made.