### PR TITLE
Set `EnableWindowsTargeting` as `true`

### DIFF
--- a/PSXPackagerGUI/PSXPackagerGUI.csproj
+++ b/PSXPackagerGUI/PSXPackagerGUI.csproj
@@ -10,6 +10,7 @@
 		<SelfContained>false</SelfContained>
 		<PublishSingleFile>true</PublishSingleFile>
 		<PublishReadyToRun>false</PublishReadyToRun>
+		<EnableWindowsTargeting>true</EnableWindowsTargeting>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
In Linux and macOS, VS Code can't open `PSXPackagerGUI.csproj` with this parameter `false`.