### PR TITLE
Fix GitHub Actions for `Update build scripts`

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -25,7 +25,6 @@ jobs:
       - name: Tar linux-x64 files
         run: |
           cd build
-          mv {,psxpackager-}linux-x64
           tar cvf psxpackager-linux-x64{.tar,}
       - name: Upload linux-x64 Tar
         uses: actions/upload-artifact@v3
@@ -35,7 +34,6 @@ jobs:
       - name: Tar linux-arm files
         run: |
           cd build
-          mv {,psxpackager-}linux-arm
           tar cvf psxpackager-linux-arm{.tar,}
       - name: Upload linux-arm Tar
         uses: actions/upload-artifact@v3
@@ -45,7 +43,6 @@ jobs:
       - name: Tar linux-arm64 files
         run: |
           cd build
-          mv {,psxpackager-}linux-arm64
           tar cvf psxpackager-linux-arm64{.tar,}
       - name: Upload linux-arm64 Tar
         uses: actions/upload-artifact@v3
@@ -55,7 +52,6 @@ jobs:
       - name: Tar osx-x64 files
         run : |
           cd build
-          mv {,psxpackager-}osx-x64
           tar cvf psxpackager-osx-x64{.tar,}
       - name: Upload osx-x64 Tar
         uses: actions/upload-artifact@v3
@@ -65,7 +61,6 @@ jobs:
       - name: Tar osx-arm64 files
         run : |
           cd build
-          mv {,psxpackager-}osx-arm64
           tar cvf psxpackager-osx-arm64{.tar,}
       - name: Upload osx-arm64 Tar
         uses: actions/upload-artifact@v3

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -20,8 +20,7 @@ jobs:
         run: make test
 
       - name: Publish
-        # run: .\build-all.cmd
-        run: make
+        run: .\build-all.cmd
 
       - name: Upload PsxPackagerGUI Artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -16,6 +16,9 @@ jobs:
         with:
           msbuild-architecture: x64
 
+      - name: Install unzip
+        run: choco install -y unzip
+
       - name: Test
         run: make test
 

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -31,5 +31,5 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: psxpackager-win-x64
-          path: build\win-x64\**
+          path: build\psxpackager-win-x64\**
 

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -17,7 +17,7 @@ jobs:
           msbuild-architecture: x64
 
       - name: Install unzip
-        run: choco install -y unzip
+        run: choco install -y zip
 
       - name: Test
         run: make test


### PR DESCRIPTION
Fix for CI Fail.

https://github.com/RupertAvery/PSXPackager/actions

fix: https://github.com/takano32/PSXPackager/actions?query=branch%3Afix-github-actions-for-update-build-scripts