### PR TITLE
Bump up version to `v1.6.4`

### DIFF
--- a/psxpackager.props
+++ b/psxpackager.props
@@ -1,8 +1,8 @@
 <Project>
   <PropertyGroup>
-    <Version>1.6.2</Version>
-    <FileVersion>1.6.2.0</FileVersion>
-    <AssemblyVersion>1.6.2.0</AssemblyVersion>
+    <Version>1.6.4</Version>
+    <FileVersion>1.6.4.0</FileVersion>
+    <AssemblyVersion>1.6.4.0</AssemblyVersion>
     <Authors>RupertAvery</Authors>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Next release is to be `v1.6.4`

see also. #58 