### PR TITLE
Upgrade from `net6.0` to `net8.0`

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -9,12 +9,12 @@ jobs:
       DOTNET_NOLOGO: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: 8.0.x
 
       - name: Test
         run: make test
@@ -27,7 +27,7 @@ jobs:
           cd build
           tar cvf psxpackager-linux-x64{.tar,}
       - name: Upload linux-x64 Tar
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: psxpackager-linux-x64
           path: build/psxpackager-linux-x64.tar
@@ -36,7 +36,7 @@ jobs:
           cd build
           tar cvf psxpackager-linux-arm{.tar,}
       - name: Upload linux-arm Tar
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: psxpackager-linux-arm
           path: build/psxpackager-linux-arm.tar
@@ -45,7 +45,7 @@ jobs:
           cd build
           tar cvf psxpackager-linux-arm64{.tar,}
       - name: Upload linux-arm64 Tar
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: psxpackager-linux-arm64
           path: build/psxpackager-linux-arm64.tar
@@ -54,7 +54,7 @@ jobs:
           cd build
           tar cvf psxpackager-osx-x64{.tar,}
       - name: Upload osx-x64 Tar
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: psxpackager-osx-x64
           path: build/psxpackager-osx-x64.tar
@@ -63,7 +63,7 @@ jobs:
           cd build
           tar cvf psxpackager-osx-arm64{.tar,}
       - name: Upload osx-arm64 Tar
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: psxpackager-osx-arm64
           path: build/psxpackager-osx-arm64.tar

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -9,10 +9,10 @@ jobs:
       DOTNET_NOLOGO: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v1.1
+        uses: microsoft/setup-msbuild@v2
         with:
           msbuild-architecture: x64
 
@@ -26,12 +26,12 @@ jobs:
         run: .\build-all.cmd
 
       - name: Upload PsxPackagerGUI Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: PsxPackagerGUI
           path: build\PsxPackagerGUI\**
       - name: Upload win-x64 Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: psxpackager-win-x64
           path: build\psxpackager-win-x64\**

--- a/PSXPackager.Common/PSXPackager.Common.csproj
+++ b/PSXPackager.Common/PSXPackager.Common.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/PSXPackager.Tests/PSXPackager.Tests.csproj
+++ b/PSXPackager.Tests/PSXPackager.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/PSXPackager/PSXPackager-linux.csproj
+++ b/PSXPackager/PSXPackager-linux.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <AssemblyName>psxpackager</AssemblyName>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 	<RuntimeIdentifier>linux-x64</RuntimeIdentifier>
 	<SelfContained>false</SelfContained>
 	<PublishSingleFile>true</PublishSingleFile>

--- a/PSXPackager/PSXPackager-windows.csproj
+++ b/PSXPackager/PSXPackager-windows.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <AssemblyName>psxpackager</AssemblyName>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 	<RuntimeIdentifier>win-x64</RuntimeIdentifier>
 	<SelfContained>false</SelfContained>
 	<PublishSingleFile>true</PublishSingleFile>

--- a/PSXPackager/PSXPackager.csproj
+++ b/PSXPackager/PSXPackager.csproj
@@ -3,7 +3,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFrameworks>net6.0</TargetFrameworks>
+		<TargetFrameworks>net8.0</TargetFrameworks>
 		<PublishTrimmed>true</PublishTrimmed>
 	</PropertyGroup>
 

--- a/PSXPackager/Properties/PublishProfiles/FolderProfile.pubxml
+++ b/PSXPackager/Properties/PublishProfiles/FolderProfile.pubxml
@@ -6,10 +6,10 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <Configuration>Release</Configuration>
     <Platform>Any CPU</Platform>
-    <PublishDir>bin\Release\net6.0\publish\win-x64\</PublishDir>
+    <PublishDir>bin\Release\net8.0\publish\win-x64\</PublishDir>
     <PublishProtocol>FileSystem</PublishProtocol>
     <_TargetId>Folder</_TargetId>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <SelfContained>false</SelfContained>
     <PublishSingleFile>true</PublishSingleFile>

--- a/PSXPackager/Properties/PublishProfiles/FolderProfile1.pubxml
+++ b/PSXPackager/Properties/PublishProfiles/FolderProfile1.pubxml
@@ -6,10 +6,10 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <Configuration>Release</Configuration>
     <Platform>Any CPU</Platform>
-    <PublishDir>bin\Release\net6.0\publish\linux-x64\</PublishDir>
+    <PublishDir>bin\Release\net8.0\publish\linux-x64\</PublishDir>
     <PublishProtocol>FileSystem</PublishProtocol>
     <_TargetId>Folder</_TargetId>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RuntimeIdentifier>linux-x64</RuntimeIdentifier>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>true</PublishSingleFile>

--- a/PSXPackagerGUI/PSXPackagerGUI.csproj
+++ b/PSXPackagerGUI/PSXPackagerGUI.csproj
@@ -3,7 +3,7 @@
 
 	<PropertyGroup>
 		<OutputType>WinExe</OutputType>
-		<TargetFramework>net6.0-windows</TargetFramework>
+		<TargetFramework>net8.0-windows</TargetFramework>
 		<UseWPF>true</UseWPF>
 		<ApplicationIcon>Resources\package-64x64.ico</ApplicationIcon>
 		<RuntimeIdentifier>win-x64</RuntimeIdentifier>

--- a/PSXPackagerGUI/Properties/PublishProfiles/FolderProfile.pubxml
+++ b/PSXPackagerGUI/Properties/PublishProfiles/FolderProfile.pubxml
@@ -6,10 +6,10 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <Configuration>Release</Configuration>
     <Platform>Any CPU</Platform>
-    <PublishDir>bin\Release\net6.0-windows\publish\win-x64\</PublishDir>
+    <PublishDir>bin\Release\net8.0-windows\publish\win-x64\</PublishDir>
     <PublishProtocol>FileSystem</PublishProtocol>
     <_TargetId>Folder</_TargetId>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <SelfContained>false</SelfContained>
     <PublishSingleFile>true</PublishSingleFile>

--- a/Popstation.Database/Popstation.Database.csproj
+++ b/Popstation.Database/Popstation.Database.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Popstation/Popstation.csproj
+++ b/Popstation/Popstation.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net6.0</TargetFrameworks>
+		<TargetFrameworks>net8.0</TargetFrameworks>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/common-library.props
+++ b/common-library.props
@@ -3,7 +3,7 @@
   
   <!-- Package related stuff -->
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
   </PropertyGroup>
     
   <!-- Assembly stuff -->


### PR DESCRIPTION
Upgrade from `net6.0` to `net8.0`

.NET 8.0 is latest LTS release

* https://dotnet.microsoft.com/en-us/download/dotnet

Ubuntu 24.04 LTS Noble Numbat will include .NET 8.0

* https://packages.ubuntu.com/noble/dotnet-sdk-8.0