### PR TITLE
Update NuGet Packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 WINDOWS_PROPERTIES=-p:EnableWindowsTargeting=true -p:PublishTrimmed=false
-SELF_CONTAINED_PROPERTIES=--self-contained -p:PublishSingleFile=true -p:SelfContained=true -p:PublishTrimmed=true -p:InvariantGlobalization=true -p:EnableCompressionInSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -p:DebugType=None -p:DebugSymbols=false
+SELF_CONTAINED_PROPERTIES=--self-contained -p:PublishSingleFile=true -p:SelfContained=true -p:PublishTrimmed=false -p:InvariantGlobalization=true -p:EnableCompressionInSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -p:DebugType=None -p:DebugSymbols=false
 
 .PHONY:	all build clean test
 

--- a/PSXPackager.Common/PSXPackager.Common.csproj
+++ b/PSXPackager.Common/PSXPackager.Common.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SharpCompress" Version="0.34.1" />
+    <PackageReference Include="SharpCompress" Version="0.36.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/PSXPackager.Tests/PSXPackager.Tests.csproj
+++ b/PSXPackager.Tests/PSXPackager.Tests.csproj
@@ -9,10 +9,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
-    <PackageReference Include="coverlet.collector" Version="6.0.0"><IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.2.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.2.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.1"><IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 <PrivateAssets>all</PrivateAssets>
 </PackageReference>
   </ItemGroup>

--- a/PSXPackager/PSXPackager-windows.csproj
+++ b/PSXPackager/PSXPackager-windows.csproj
@@ -13,7 +13,6 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="SharpCompress" Version="0.34.1" />
   </ItemGroup>
 
   <ItemGroup> 

--- a/PSXPackager/PSXPackager.csproj
+++ b/PSXPackager/PSXPackager.csproj
@@ -9,7 +9,6 @@
 
 	<ItemGroup>
 		<PackageReference Include="CommandLineParser" Version="2.9.1" />
-		<PackageReference Include="SharpCompress" Version="0.36.0" />
 		<PackageReference Include="System.ValueTuple" Version="4.5.0" />
 	</ItemGroup>
 

--- a/PSXPackager/PSXPackager.csproj
+++ b/PSXPackager/PSXPackager.csproj
@@ -9,7 +9,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="CommandLineParser" Version="2.9.1" />
-		<PackageReference Include="SharpCompress" Version="0.34.1" />
+		<PackageReference Include="SharpCompress" Version="0.36.0" />
 		<PackageReference Include="System.ValueTuple" Version="4.5.0" />
 	</ItemGroup>
 

--- a/PSXPackagerGUI/PSXPackagerGUI.csproj
+++ b/PSXPackagerGUI/PSXPackagerGUI.csproj
@@ -31,7 +31,7 @@
 	<ItemGroup>
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<PackageReference Include="Ookii.Dialogs.Wpf" Version="5.0.1" />
-		<PackageReference Include="SharpCompress" Version="0.34.1" />
+		<PackageReference Include="SharpCompress" Version="0.36.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/PSXPackagerGUI/PSXPackagerGUI.csproj
+++ b/PSXPackagerGUI/PSXPackagerGUI.csproj
@@ -31,7 +31,6 @@
 	<ItemGroup>
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<PackageReference Include="Ookii.Dialogs.Wpf" Version="5.0.1" />
-		<PackageReference Include="SharpCompress" Version="0.36.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Popstation/Popstation.csproj
+++ b/Popstation/Popstation.csproj
@@ -14,7 +14,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="SharpZipLib" Version="1.4.2" />
-		<PackageReference Include="SharpCompress" Version="0.34.1" />
+		<PackageReference Include="SharpCompress" Version="0.36.0" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Popstation
* 更新:
  * SharpCompress.0.34.1 -> SharpCompress.0.36.0
  * ZstdSharp.Port.0.7.2 -> ZstdSharp.Port.0.7.4

PSXPackager.Common
* 更新:
  * SharpCompress.0.34.1 -> SharpCompress.0.36.0
  * ZstdSharp.Port.0.7.2 -> ZstdSharp.Port.0.7.4

PSXPackager
* 更新:
  * SharpCompress.0.34.1 -> SharpCompress.0.36.0
  * ZstdSharp.Port.0.7.2 -> ZstdSharp.Port.0.7.4

PSXPackagerGUI
* 更新:
  * SharpCompress.0.34.1 -> SharpCompress.0.36.0
  * ZstdSharp.Port.0.7.2 -> ZstdSharp.Port.0.7.4

PSXPackager.Tests
* アンインストール中:
  * NuGet.Frameworks.6.5.0
* 更新:
  * coverlet.collector.6.0.0 -> coverlet.collector.6.0.1
  * Microsoft.CodeCoverage.17.7.2 -> Microsoft.CodeCoverage.17.9.0
  * Microsoft.NET.Test.Sdk.17.7.2 -> Microsoft.NET.Test.Sdk.17.9.0
  * Microsoft.TestPlatform.ObjectModel.17.7.2 -> Microsoft.TestPlatform.ObjectModel.17.9.0
  * Microsoft.TestPlatform.TestHost.17.7.2 -> Microsoft.TestPlatform.TestHost.17.9.0
  * MSTest.TestAdapter.3.1.1 -> MSTest.TestAdapter.3.2.2
  * MSTest.TestFramework.3.1.1 -> MSTest.TestFramework.3.2.2
* インストール中:
  * Microsoft.ApplicationInsights.2.21.0
  * Microsoft.Testing.Extensions.Telemetry.1.0.2
  * Microsoft.Testing.Extensions.TrxReport.Abstractions.1.0.2
  * Microsoft.Testing.Extensions.VSTestBridge.1.0.2
  * Microsoft.Testing.Platform.1.0.2
  * Microsoft.Testing.Platform.MSBuild.1.0.2
  * System.Diagnostics.DiagnosticSource.5.0.0