### PR TITLE
Fix `SYSLIB0051` warnings

### DIFF
--- a/DiscUtils.Core/InvalidFileSystemException.cs
+++ b/DiscUtils.Core/InvalidFileSystemException.cs
@@ -56,17 +56,5 @@ namespace DiscUtils
         /// <param name="innerException">The inner exception.</param>
         public InvalidFileSystemException(string message, Exception innerException)
             : base(message, innerException) {}
-
-#if !NETSTANDARD1_5
-        /// <summary>
-        /// Initializes a new instance of the InvalidFileSystemException class.
-        /// </summary>
-        /// <param name="info">The serialization info.</param>
-        /// <param name="context">The streaming context.</param>
-        protected InvalidFileSystemException(SerializationInfo info, StreamingContext context)
-            : base(info, context)
-        {
-        }
-#endif
     }
 }


### PR DESCRIPTION
Fix below warnings

> build: DiscUtils.Core/InvalidFileSystemException.cs#L67'IOException.IOException(SerializationInfo, StreamingContext)' is obsolete: 'This API supports obsolete formatter-based serialization. It should not be called or extended by application code.' (https://aka.ms/dotnet-warnings/SYSLIB0051)