### PR TITLE
Update GitHub Actions: From v4 to v5 in some actions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -9,10 +9,10 @@ jobs:
       DOTNET_NOLOGO: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 8.0.x
 
@@ -27,7 +27,7 @@ jobs:
           cd build
           tar cvf psxpackager-linux-x64{.tar,}
       - name: Upload linux-x64 Tar
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: psxpackager-linux-x64
           path: build/psxpackager-linux-x64.tar
@@ -36,7 +36,7 @@ jobs:
           cd build
           tar cvf psxpackager-linux-arm{.tar,}
       - name: Upload linux-arm Tar
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: psxpackager-linux-arm
           path: build/psxpackager-linux-arm.tar
@@ -45,7 +45,7 @@ jobs:
           cd build
           tar cvf psxpackager-linux-arm64{.tar,}
       - name: Upload linux-arm64 Tar
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: psxpackager-linux-arm64
           path: build/psxpackager-linux-arm64.tar
@@ -54,7 +54,7 @@ jobs:
           cd build
           tar cvf psxpackager-osx-x64{.tar,}
       - name: Upload osx-x64 Tar
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: psxpackager-osx-x64
           path: build/psxpackager-osx-x64.tar
@@ -63,7 +63,7 @@ jobs:
           cd build
           tar cvf psxpackager-osx-arm64{.tar,}
       - name: Upload osx-arm64 Tar
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: psxpackager-osx-arm64
           path: build/psxpackager-osx-arm64.tar

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -9,7 +9,7 @@ jobs:
       DOTNET_NOLOGO: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v2
@@ -26,12 +26,12 @@ jobs:
         run: .\build-all.cmd
 
       - name: Upload PsxPackagerGUI Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: PsxPackagerGUI
           path: build\PsxPackagerGUI\**
       - name: Upload win-x64 Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: psxpackager-win-x64
           path: build\psxpackager-win-x64\**


### PR DESCRIPTION
Remove GItHub Actions Warnings.

ref.

- https://github.com/RupertAvery/PSXPackager/actions/runs/23486572821

- https://github.com/RupertAvery/PSXPackager/actions/runs/23486572816