### PR TITLE
Update SharpCompress from v0.36.0 to v0.42.0

### DIFF
--- a/PSXPackager.Common/PSXPackager.Common.csproj
+++ b/PSXPackager.Common/PSXPackager.Common.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SharpCompress" Version="0.36.0" />
+    <PackageReference Include="SharpCompress" Version="0.42.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Popstation/Popstation.csproj
+++ b/Popstation/Popstation.csproj
@@ -14,7 +14,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="SharpZipLib" Version="1.4.2" />
-		<PackageReference Include="SharpCompress" Version="0.36.0" />
+		<PackageReference Include="SharpCompress" Version="0.42.0" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
This keeps compatibility with the existing ArchiveFactory-based code while updating SharpCompress to the latest version that does not require code changes.