### PR TITLE
Remove `warning CS8632`

### DIFF
--- a/PSXPackager.Common/Cue/CueTrack.cs
+++ b/PSXPackager.Common/Cue/CueTrack.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 
 using System.Collections.Generic;
 

--- a/PSXPackager.Common/Cue/CueTrack.cs
+++ b/PSXPackager.Common/Cue/CueTrack.cs
@@ -1,13 +1,15 @@
-﻿using System.Collections.Generic;
+﻿#nullable enable
+
+using System.Collections.Generic;
 
 namespace PSXPackager.Common.Cue
 {
     public class CueTrack
     {
         public int Number { get; set; }
-        public string DataType { get; set; }
-        public List<CueIndex> Indexes { get; set; }
-        public CueFileEntry FileEntry { get; set; }
+        public string DataType { get; set; } = string.Empty;
+        public List<CueIndex> Indexes { get; set; } = new();
+        public CueFileEntry FileEntry { get; set; } = null!;
         public CueTrack? Next { get; set; }
     }
 }

--- a/PSXPackager.Common/TOCHelper.cs
+++ b/PSXPackager.Common/TOCHelper.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 
 using System;
 using System.Collections.Generic;

--- a/PSXPackager.Common/TOCHelper.cs
+++ b/PSXPackager.Common/TOCHelper.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#nullable enable
+
+using System;
 using System.Collections.Generic;
 using PSXPackager.Common.Cue;
 


### PR DESCRIPTION
Remove warnings.

```
warning CS8632: The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.
```