### PR TITLE
Update GitHub Actions to latest stable major versions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -9,7 +9,7 @@ jobs:
       DOTNET_NOLOGO: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
@@ -27,7 +27,7 @@ jobs:
           cd build
           tar cvf psxpackager-linux-x64{.tar,}
       - name: Upload linux-x64 Tar
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: psxpackager-linux-x64
           path: build/psxpackager-linux-x64.tar
@@ -36,7 +36,7 @@ jobs:
           cd build
           tar cvf psxpackager-linux-arm{.tar,}
       - name: Upload linux-arm Tar
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: psxpackager-linux-arm
           path: build/psxpackager-linux-arm.tar
@@ -45,7 +45,7 @@ jobs:
           cd build
           tar cvf psxpackager-linux-arm64{.tar,}
       - name: Upload linux-arm64 Tar
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: psxpackager-linux-arm64
           path: build/psxpackager-linux-arm64.tar
@@ -54,7 +54,7 @@ jobs:
           cd build
           tar cvf psxpackager-osx-x64{.tar,}
       - name: Upload osx-x64 Tar
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: psxpackager-osx-x64
           path: build/psxpackager-osx-x64.tar
@@ -63,7 +63,7 @@ jobs:
           cd build
           tar cvf psxpackager-osx-arm64{.tar,}
       - name: Upload osx-arm64 Tar
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: psxpackager-osx-arm64
           path: build/psxpackager-osx-arm64.tar

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -9,10 +9,10 @@ jobs:
       DOTNET_NOLOGO: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v2
+        uses: microsoft/setup-msbuild@v3
         with:
           msbuild-architecture: x64
 
@@ -26,12 +26,12 @@ jobs:
         run: .\build-all.cmd
 
       - name: Upload PsxPackagerGUI Artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: PsxPackagerGUI
           path: build\PsxPackagerGUI\**
       - name: Upload win-x64 Artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: psxpackager-win-x64
           path: build\psxpackager-win-x64\**


### PR DESCRIPTION
This updates GitHub Actions to the latest stable major versions:

- actions/checkout from v5 to v6
- actions/upload-artifact from v5 to v7
- microsoft/setup-msbuild from v2 to v3

actions/setup-dotnet is already on the latest stable major version, v5.

No workflow behavior is intended to change.