### PR TITLE
Add unit tests for previously untested core logic

### DIFF
--- a/PSXPackager.Tests/CueExtensionsTests.cs
+++ b/PSXPackager.Tests/CueExtensionsTests.cs
@@ -1,0 +1,41 @@
+using PSXPackager.Common.Cue;
+
+namespace UnitTestProject
+{
+    [TestClass]
+    public class CueExtensionsTests
+    {
+        [TestMethod]
+        public void ToSectorConvertsMinutesSecondsFramesToAbsoluteFrameCount()
+        {
+            var position = new IndexPosition(1, 2, 3);
+
+            // 1 minute * 60 * 75 + 2 seconds * 75 + 3 frames
+            Assert.AreEqual(1 * 60 * 75 + 2 * 75 + 3, position.ToSector());
+        }
+
+        [TestMethod]
+        public void ToSectorAtOriginIsZero()
+        {
+            var position = new IndexPosition(0, 0, 0);
+
+            Assert.AreEqual(0, position.ToSector());
+        }
+
+        [TestMethod]
+        public void ToByteOffsetMultipliesSectorBy2352()
+        {
+            var position = new IndexPosition(0, 1, 0);
+
+            Assert.AreEqual(75L * 2352, position.ToByteOffset());
+        }
+
+        [TestMethod]
+        public void ToByteOffsetAtOriginIsZero()
+        {
+            var position = new IndexPosition(0, 0, 0);
+
+            Assert.AreEqual(0L, position.ToByteOffset());
+        }
+    }
+}

--- a/PSXPackager.Tests/CueFileReadWriteTests.cs
+++ b/PSXPackager.Tests/CueFileReadWriteTests.cs
@@ -1,0 +1,167 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using PSXPackager.Common.Cue;
+
+namespace UnitTestProject
+{
+    [TestClass]
+    public class CueFileReadWriteTests
+    {
+        private string _tempCuePath = string.Empty;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _tempCuePath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName() + ".cue");
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            if (File.Exists(_tempCuePath))
+            {
+                File.Delete(_tempCuePath);
+            }
+        }
+
+        private static CueFile BuildSampleCueFile()
+        {
+            var cueFile = new CueFile();
+
+            var fileEntry = new CueFileEntry
+            {
+                CueFile = cueFile,
+                FileName = "game.bin",
+                FileType = FileTypes.BINARY,
+                Tracks = new List<CueTrack>(),
+            };
+
+            var dataTrack = new CueTrack
+            {
+                FileEntry = fileEntry,
+                Number = 1,
+                DataType = DataTypes.DATA,
+                Indexes = new List<CueIndex>
+                {
+                    new CueIndex { Number = 1, Position = new IndexPosition(0, 0, 0) },
+                },
+            };
+
+            var audioTrack = new CueTrack
+            {
+                FileEntry = fileEntry,
+                Number = 2,
+                DataType = DataTypes.AUDIO,
+                Indexes = new List<CueIndex>
+                {
+                    new CueIndex { Number = 0, Position = new IndexPosition(2, 58, 0) },
+                    new CueIndex { Number = 1, Position = new IndexPosition(3, 0, 0) },
+                },
+            };
+
+            dataTrack.Next = audioTrack;
+
+            fileEntry.Tracks.Add(dataTrack);
+            fileEntry.Tracks.Add(audioTrack);
+
+            cueFile.FileEntries.Add(fileEntry);
+
+            return cueFile;
+        }
+
+        [TestMethod]
+        public void WriteThenReadRoundTripsFileTracksAndIndexes()
+        {
+            var original = BuildSampleCueFile();
+
+            CueFileWriter.Write(original, _tempCuePath);
+            var roundTripped = CueFileReader.Read(_tempCuePath);
+
+            Assert.AreEqual(1, roundTripped.FileEntries.Count);
+
+            var entry = roundTripped.FileEntries[0];
+            Assert.AreEqual("game.bin", entry.FileName);
+            Assert.AreEqual(FileTypes.BINARY, entry.FileType);
+            Assert.AreEqual(2, entry.Tracks.Count);
+
+            var dataTrack = entry.Tracks[0];
+            Assert.AreEqual(1, dataTrack.Number);
+            Assert.AreEqual(DataTypes.DATA, dataTrack.DataType);
+            Assert.AreEqual(1, dataTrack.Indexes.Count);
+            Assert.AreEqual(0, dataTrack.Indexes[0].Position.Minutes);
+            Assert.AreEqual(0, dataTrack.Indexes[0].Position.Seconds);
+            Assert.AreEqual(0, dataTrack.Indexes[0].Position.Frames);
+
+            var audioTrack = entry.Tracks[1];
+            Assert.AreEqual(2, audioTrack.Number);
+            Assert.AreEqual(DataTypes.AUDIO, audioTrack.DataType);
+            Assert.AreEqual(2, audioTrack.Indexes.Count);
+
+            Assert.AreEqual(0, audioTrack.Indexes[0].Number);
+            Assert.AreEqual(2, audioTrack.Indexes[0].Position.Minutes);
+            Assert.AreEqual(58, audioTrack.Indexes[0].Position.Seconds);
+            Assert.AreEqual(0, audioTrack.Indexes[0].Position.Frames);
+
+            Assert.AreEqual(1, audioTrack.Indexes[1].Number);
+            Assert.AreEqual(3, audioTrack.Indexes[1].Position.Minutes);
+            Assert.AreEqual(0, audioTrack.Indexes[1].Position.Seconds);
+            Assert.AreEqual(0, audioTrack.Indexes[1].Position.Frames);
+        }
+
+        [TestMethod]
+        public void ReadLinksConsecutiveTracksWithinAFileEntryViaNext()
+        {
+            var original = BuildSampleCueFile();
+
+            CueFileWriter.Write(original, _tempCuePath);
+            var roundTripped = CueFileReader.Read(_tempCuePath);
+
+            var tracks = roundTripped.FileEntries[0].Tracks;
+
+            Assert.AreSame(tracks[1], tracks[0].Next);
+            Assert.IsNull(tracks[1].Next);
+        }
+
+        [TestMethod]
+        public void GetAbsolutePathCombinesCueDirectoryWithRelativeFileName()
+        {
+            var cueFile = new CueFile { Path = _tempCuePath };
+            var fileEntry = new CueFileEntry { FileName = "game.bin" };
+
+            var absolutePath = cueFile.GetAbsolutePath(fileEntry);
+
+            Assert.AreEqual(Path.Combine(Path.GetDirectoryName(_tempCuePath)!, "game.bin"), absolutePath);
+        }
+
+        [TestMethod]
+        public void GetAbsolutePathReturnsFileNameUnchangedWhenAlreadyFullyQualified()
+        {
+            var cueFile = new CueFile { Path = _tempCuePath };
+            var fullyQualified = Path.Combine(Path.GetTempPath(), "elsewhere", "game.bin");
+            var fileEntry = new CueFileEntry { FileName = fullyQualified };
+
+            var absolutePath = cueFile.GetAbsolutePath(fileEntry);
+
+            Assert.AreEqual(fullyQualified, absolutePath);
+        }
+
+        [TestMethod]
+        public void DummyCreatesSingleDataTrackStartingAtZero()
+        {
+            var cueFile = CueFileReader.Dummy("game.bin");
+
+            Assert.AreEqual(1, cueFile.FileEntries.Count);
+            Assert.AreEqual("game.bin", cueFile.FileEntries[0].FileName);
+            Assert.AreEqual(1, cueFile.FileEntries[0].Tracks.Count);
+
+            var track = cueFile.FileEntries[0].Tracks[0];
+            Assert.AreEqual(1, track.Number);
+            Assert.AreEqual(DataTypes.DATA, track.DataType);
+            Assert.AreEqual(1, track.Indexes.Count);
+            Assert.AreEqual(0, track.Indexes[0].Position.Minutes);
+            Assert.AreEqual(0, track.Indexes[0].Position.Seconds);
+            Assert.AreEqual(0, track.Indexes[0].Position.Frames);
+        }
+    }
+}

--- a/PSXPackager.Tests/FileExtensionHelperTests.cs
+++ b/PSXPackager.Tests/FileExtensionHelperTests.cs
@@ -1,0 +1,70 @@
+using PSXPackager.Common;
+
+namespace UnitTestProject
+{
+    [TestClass]
+    public class FileExtensionHelperTests
+    {
+        [DataTestMethod]
+        [DataRow("game.cue", true)]
+        [DataRow("game.CUE", true)]
+        [DataRow("game.bin", false)]
+        [DataRow("game", false)]
+        public void IsCue(string filename, bool expected)
+        {
+            Assert.AreEqual(expected, FileExtensionHelper.IsCue(filename));
+        }
+
+        [DataTestMethod]
+        [DataRow("game.pbp", true)]
+        [DataRow("game.PBP", true)]
+        [DataRow("game.bin", false)]
+        public void IsPbp(string filename, bool expected)
+        {
+            Assert.AreEqual(expected, FileExtensionHelper.IsPbp(filename));
+        }
+
+        [DataTestMethod]
+        [DataRow("playlist.m3u", true)]
+        [DataRow("playlist.M3U", true)]
+        [DataRow("playlist.cue", false)]
+        public void IsM3u(string filename, bool expected)
+        {
+            Assert.AreEqual(expected, FileExtensionHelper.IsM3u(filename));
+        }
+
+        [DataTestMethod]
+        [DataRow("archive.rar", true)]
+        [DataRow("archive.zip", true)]
+        [DataRow("archive.tar", true)]
+        [DataRow("archive.gz", true)]
+        [DataRow("archive.7z", true)]
+        [DataRow("archive.ZIP", true)]
+        [DataRow("game.bin", false)]
+        [DataRow("game.iso", false)]
+        public void IsArchive(string filename, bool expected)
+        {
+            Assert.AreEqual(expected, FileExtensionHelper.IsArchive(filename));
+        }
+
+        [DataTestMethod]
+        [DataRow("track01.bin", true)]
+        [DataRow("track01.BIN", true)]
+        [DataRow("game.iso", false)]
+        public void IsBin(string filename, bool expected)
+        {
+            Assert.AreEqual(expected, FileExtensionHelper.IsBin(filename));
+        }
+
+        [DataTestMethod]
+        [DataRow("track01.bin", true)]
+        [DataRow("disc.img", true)]
+        [DataRow("disc.iso", true)]
+        [DataRow("disc.cue", false)]
+        [DataRow("disc.pbp", false)]
+        public void IsImageFile(string filename, bool expected)
+        {
+            Assert.AreEqual(expected, FileExtensionHelper.IsImageFile(filename));
+        }
+    }
+}

--- a/PSXPackager.Tests/GameDBTests.cs
+++ b/PSXPackager.Tests/GameDBTests.cs
@@ -1,0 +1,159 @@
+using System.IO;
+using Popstation.Database;
+
+namespace UnitTestProject
+{
+    [TestClass]
+    public class GameDBTests
+    {
+        private string _tempDbPath = string.Empty;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _tempDbPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName() + ".db");
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            if (File.Exists(_tempDbPath))
+            {
+                File.Delete(_tempDbPath);
+            }
+        }
+
+        [DataTestMethod]
+        [DataRow("SLUS-00001", "U")]
+        [DataRow("SLUS00001", "U")]
+        [DataRow("slus-00001", "U")]
+        [DataRow("SCUS-00001", "U")]
+        [DataRow("SLES-00001", "P")]
+        [DataRow("SCES-00001", "P")]
+        [DataRow("SCED-00001", "P")]
+        [DataRow("SLED-00001", "P")]
+        [DataRow("SLPS-00001", "J")]
+        [DataRow("SLPM-00001", "J")]
+        [DataRow("SCPS-00001", "J")]
+        [DataRow("SIPS-00001", "U")]
+        [DataRow("not-a-game-id", "U")]
+        public void GetRegionLetterMapsPartyCodeToRegion(string gameId, string expectedRegion)
+        {
+            Assert.AreEqual(expectedRegion, GameDB.GetRegionLetter(gameId));
+        }
+
+        [TestMethod]
+        public void ConstructorMapsSemicolonDelimitedFieldsToGameEntry()
+        {
+            File.WriteAllLines(_tempDbPath, new[]
+            {
+                "SLUS-00001;MAIN1;Main Game Title;Disc 1 Title;NTSC-U;MAIN1",
+            });
+
+            var gameDb = new GameDB(_tempDbPath);
+
+            Assert.AreEqual(1, gameDb.GameEntries.Count);
+            var entry = gameDb.GameEntries[0];
+            Assert.AreEqual("SLUS-00001", entry.SerialID);
+            Assert.AreEqual("MAIN1", entry.MainGameID);
+            Assert.AreEqual("Main Game Title", entry.MainGameTitle);
+            Assert.AreEqual("Disc 1 Title", entry.Title);
+            Assert.AreEqual("NTSC-U", entry.Region);
+            Assert.AreEqual("MAIN1", entry.GameID);
+        }
+
+        [TestMethod]
+        public void ConstructorPopulatesDiscCountWhenGameIdMatchesMainGameId()
+        {
+            // DiscCount is looked up by GameEntry.GameID (parts[5]) against a table keyed
+            // by MainGameID (parts[1]) - it only ends up populated for rows where those two
+            // columns hold the same value, as with the "main" disc's row here.
+            File.WriteAllLines(_tempDbPath, new[]
+            {
+                "SLUS-00001;MAIN1;Main Game Title;Disc 1 Title;NTSC-U;MAIN1",
+            });
+
+            var gameDb = new GameDB(_tempDbPath);
+
+            Assert.AreEqual(1, gameDb.GameEntries[0].DiscCount);
+        }
+
+        [TestMethod]
+        public void ConstructorLeavesDiscCountAtZeroWhenGameIdDiffersFromMainGameId()
+        {
+            File.WriteAllLines(_tempDbPath, new[]
+            {
+                "SLUS-00002;MAIN1;Main Game Title;Disc 2 Title;NTSC-U;GID2",
+            });
+
+            var gameDb = new GameDB(_tempDbPath);
+
+            Assert.AreEqual(0, gameDb.GameEntries[0].DiscCount);
+        }
+
+        [TestMethod]
+        public void ConstructorAssignsDiscIndexOneToEveryRow()
+        {
+            // DiscIndex is meant to increment for consecutive rows sharing the same
+            // MainGameID, but the comparison is against a tracking variable that is never
+            // updated after initialization - so every row currently gets DiscIndex 1,
+            // even across consecutive same-MainGameID rows. This test pins that behavior.
+            File.WriteAllLines(_tempDbPath, new[]
+            {
+                "SLUS-00001;MAIN1;Main Game Title;Disc 1 Title;NTSC-U;MAIN1",
+                "SLUS-00002;MAIN1;Main Game Title;Disc 2 Title;NTSC-U;GID2",
+                "SLUS-00003;MAIN2;Other Game Title;Other Game Title;NTSC-U;MAIN2",
+            });
+
+            var gameDb = new GameDB(_tempDbPath);
+
+            Assert.AreEqual(1, gameDb.GameEntries[0].DiscIndex);
+            Assert.AreEqual(1, gameDb.GameEntries[1].DiscIndex);
+            Assert.AreEqual(1, gameDb.GameEntries[2].DiscIndex);
+        }
+
+        [TestMethod]
+        public void GetEntryByGameIDFindsEntryStoredInUppercase()
+        {
+            File.WriteAllLines(_tempDbPath, new[]
+            {
+                "SLUS-00001;MAIN1;Main Game Title;Disc 1 Title;NTSC-U;MAIN1",
+            });
+
+            var gameDb = new GameDB(_tempDbPath);
+
+            var entry = gameDb.GetEntryByGameID("main1");
+
+            Assert.IsNotNull(entry);
+            Assert.AreEqual("MAIN1", entry.GameID);
+        }
+
+        [TestMethod]
+        public void GetEntryByGameIDReturnsNullWhenStoredGameIdIsNotUppercase()
+        {
+            // GetEntryByGameID compares the stored GameID as-is against gameId.ToUpper(),
+            // so a stored GameID that isn't already uppercase can never match.
+            File.WriteAllLines(_tempDbPath, new[]
+            {
+                "SLUS-00001;MAIN1;Main Game Title;Disc 1 Title;NTSC-U;Main1",
+            });
+
+            var gameDb = new GameDB(_tempDbPath);
+
+            Assert.IsNull(gameDb.GetEntryByGameID("main1"));
+        }
+
+        [TestMethod]
+        public void GetEntryByGameIDReturnsNullWhenNotFound()
+        {
+            File.WriteAllLines(_tempDbPath, new[]
+            {
+                "SLUS-00001;MAIN1;Main Game Title;Disc 1 Title;NTSC-U;MAIN1",
+            });
+
+            var gameDb = new GameDB(_tempDbPath);
+
+            Assert.IsNull(gameDb.GetEntryByGameID("DOES-NOT-EXIST"));
+        }
+    }
+}

--- a/PSXPackager.Tests/M3uFileReaderTests.cs
+++ b/PSXPackager.Tests/M3uFileReaderTests.cs
@@ -1,0 +1,80 @@
+using System.IO;
+using Popstation.M3u;
+
+namespace UnitTestProject
+{
+    [TestClass]
+    public class M3uFileReaderTests
+    {
+        private string _tempM3uPath = string.Empty;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _tempM3uPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName() + ".m3u");
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            if (File.Exists(_tempM3uPath))
+            {
+                File.Delete(_tempM3uPath);
+            }
+        }
+
+        [TestMethod]
+        public void ReadReturnsEachNonEmptyLineAsAnEntry()
+        {
+            File.WriteAllLines(_tempM3uPath, new[]
+            {
+                "Disc 1.cue",
+                "Disc 2.cue",
+                "Disc 3.cue",
+            });
+
+            var m3u = M3uFileReader.Read(_tempM3uPath);
+
+            CollectionAssert.AreEqual(new[] { "Disc 1.cue", "Disc 2.cue", "Disc 3.cue" }, m3u.FileEntries);
+        }
+
+        [TestMethod]
+        public void ReadSkipsBlankAndWhitespaceOnlyLines()
+        {
+            File.WriteAllLines(_tempM3uPath, new[]
+            {
+                "Disc 1.cue",
+                "",
+                "   ",
+                "Disc 2.cue",
+            });
+
+            var m3u = M3uFileReader.Read(_tempM3uPath);
+
+            CollectionAssert.AreEqual(new[] { "Disc 1.cue", "Disc 2.cue" }, m3u.FileEntries);
+        }
+
+        [TestMethod]
+        public void ReadTrimsSurroundingWhitespaceFromEntries()
+        {
+            File.WriteAllLines(_tempM3uPath, new[]
+            {
+                "  Disc 1.cue  ",
+            });
+
+            var m3u = M3uFileReader.Read(_tempM3uPath);
+
+            Assert.AreEqual("Disc 1.cue", m3u.FileEntries[0]);
+        }
+
+        [TestMethod]
+        public void ReadSetsPathToTheFileThatWasRead()
+        {
+            File.WriteAllLines(_tempM3uPath, new[] { "Disc 1.cue" });
+
+            var m3u = M3uFileReader.Read(_tempM3uPath);
+
+            Assert.AreEqual(_tempM3uPath, m3u.Path);
+        }
+    }
+}

--- a/PSXPackager.Tests/PSXPackager.Tests.csproj
+++ b/PSXPackager.Tests/PSXPackager.Tests.csproj
@@ -19,5 +19,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\PSXPackager.Common\PSXPackager.Common.csproj" />
+    <ProjectReference Include="..\Popstation\Popstation.csproj" />
   </ItemGroup>
 </Project>

--- a/PSXPackager.Tests/PSXPackager.Tests.csproj
+++ b/PSXPackager.Tests/PSXPackager.Tests.csproj
@@ -20,5 +20,6 @@
   <ItemGroup>
     <ProjectReference Include="..\PSXPackager.Common\PSXPackager.Common.csproj" />
     <ProjectReference Include="..\Popstation\Popstation.csproj" />
+    <ProjectReference Include="..\Popstation.Database\Popstation.Database.csproj" />
   </ItemGroup>
 </Project>

--- a/PSXPackager.Tests/PbpReaderTests.cs
+++ b/PSXPackager.Tests/PbpReaderTests.cs
@@ -1,0 +1,143 @@
+using System;
+using System.IO;
+using System.Runtime.CompilerServices;
+using Popstation.Pbp;
+
+namespace UnitTestProject
+{
+    [TestClass]
+    public class PbpReaderTests
+    {
+        // Header slot offsets, mirroring the private constants in PbpReader
+        private const int Icon0Offset = 0x0C;
+        private const int Icon1Offset = 0x10;
+        private const int Pic0Offset = 0x14;
+        private const int Snd0Offset = 0x1C;
+        private const int PsarOffset = 0x24;
+
+        private static void WriteInt32At(byte[] buffer, int offset, int value)
+        {
+            BitConverter.GetBytes(value).CopyTo(buffer, offset);
+        }
+
+        /// <summary>
+        /// Seek() and TryGetResourceStream() only operate on the stream argument they're
+        /// given - they don't touch the Discs/SFOData built by the constructor. The
+        /// constructor itself requires a byte-perfect valid PBP (including a parseable
+        /// disc TOC), which is impractical to hand-build just to exercise this header
+        /// arithmetic, so tests here bypass it and construct an uninitialized instance.
+        /// </summary>
+        private static PbpReader CreateReaderWithoutRunningConstructor()
+        {
+            return (PbpReader)RuntimeHelpers.GetUninitializedObject(typeof(PbpReader));
+        }
+
+        [TestMethod]
+        public void SeekReturnsDifferenceBetweenStartAndEndHeaderSlots()
+        {
+            // ICON0's length is defined by the gap between its own header slot and the
+            // next resource's header slot (ICON1), which stores ICON0's end offset.
+            var buffer = new byte[Icon1Offset + 4];
+            WriteInt32At(buffer, Icon0Offset, 100);
+            WriteInt32At(buffer, Icon1Offset, 150);
+
+            using var stream = new MemoryStream(buffer);
+            var reader = CreateReaderWithoutRunningConstructor();
+
+            var length = reader.Seek(ResourceType.ICON0, stream);
+
+            Assert.AreEqual(50, length);
+        }
+
+        [TestMethod]
+        public void SeekPositionsStreamAtTheStartOffset()
+        {
+            var buffer = new byte[Icon1Offset + 4];
+            WriteInt32At(buffer, Icon0Offset, 100);
+            WriteInt32At(buffer, Icon1Offset, 150);
+
+            using var stream = new MemoryStream(buffer);
+            var reader = CreateReaderWithoutRunningConstructor();
+
+            reader.Seek(ResourceType.ICON0, stream);
+
+            Assert.AreEqual(100, stream.Position);
+        }
+
+        [TestMethod]
+        public void SeekForPsarUsesStreamLengthAsTheEndOffset()
+        {
+            // PSAR has no "next" header slot - it runs to the end of the file.
+            var buffer = new byte[48];
+            WriteInt32At(buffer, PsarOffset, 16);
+
+            using var stream = new MemoryStream(buffer);
+            var reader = CreateReaderWithoutRunningConstructor();
+
+            var length = reader.Seek(ResourceType.PSAR, stream);
+
+            Assert.AreEqual(buffer.Length - 16, length);
+            Assert.AreEqual(16, stream.Position);
+        }
+
+        [TestMethod]
+        public void SeekThrowsForAResourceTypeWithNoHeaderSlot()
+        {
+            var buffer = new byte[Icon1Offset + 4];
+            using var stream = new MemoryStream(buffer);
+            var reader = CreateReaderWithoutRunningConstructor();
+
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => reader.Seek(ResourceType.BOOT, stream));
+        }
+
+        [TestMethod]
+        public void TryGetResourceStreamReturnsTrueWithResourceBytesWhenLengthIsPositive()
+        {
+            var buffer = new byte[24];
+            WriteInt32At(buffer, Icon0Offset, 20);
+            WriteInt32At(buffer, Icon1Offset, 24);
+            buffer[20] = 0xDE;
+            buffer[21] = 0xAD;
+            buffer[22] = 0xBE;
+            buffer[23] = 0xEF;
+
+            using var stream = new MemoryStream(buffer);
+            var reader = CreateReaderWithoutRunningConstructor();
+
+            var found = reader.TryGetResourceStream(ResourceType.ICON0, stream, out var resourceStream);
+
+            Assert.IsTrue(found);
+            using var memoryStream = new MemoryStream();
+            resourceStream.CopyTo(memoryStream);
+            CollectionAssert.AreEqual(new byte[] { 0xDE, 0xAD, 0xBE, 0xEF }, memoryStream.ToArray());
+        }
+
+        [TestMethod]
+        public void TryGetResourceStreamReturnsFalseWhenStartEqualsEnd()
+        {
+            var buffer = new byte[Snd0Offset + 8];
+            WriteInt32At(buffer, Pic0Offset, 10);
+            // ICON1..PIC0's "end" slot is PIC0 itself in this arrangement; make it degenerate
+            // by pointing PIC0's own start and the following slot at the same offset.
+            WriteInt32At(buffer, Pic0Offset + 4, 10);
+
+            using var stream = new MemoryStream(buffer);
+            var reader = CreateReaderWithoutRunningConstructor();
+
+            var found = reader.TryGetResourceStream(ResourceType.PIC0, stream, out var resourceStream);
+
+            Assert.IsFalse(found);
+            Assert.IsNull(resourceStream);
+        }
+
+        [TestMethod]
+        public void ConstructorThrowsWhenMagicHeaderIsInvalid()
+        {
+            var buffer = new byte[32]; // all zeros - not the PBP magic
+
+            using var stream = new MemoryStream(buffer);
+
+            Assert.ThrowsException<Exception>(() => new PbpReader(stream));
+        }
+    }
+}

--- a/PSXPackager.Tests/PopstationFilenameFormatTests.cs
+++ b/PSXPackager.Tests/PopstationFilenameFormatTests.cs
@@ -1,0 +1,98 @@
+using Popstation;
+using Popstation.Pbp;
+
+namespace UnitTestProject
+{
+    [TestClass]
+    public class PopstationFilenameFormatTests
+    {
+        [DataTestMethod]
+        [DataRow("%FILENAME%")]
+        [DataRow("%GAMEID%")]
+        [DataRow("%MAINGAMEID%")]
+        [DataRow("%TITLE%")]
+        [DataRow("%MAINTITLE%")]
+        [DataRow("%REGION%")]
+        public void CheckFormatIsTrueForEachRecognizedPlaceholder(string placeholder)
+        {
+            Assert.IsTrue(Popstation.Popstation.CheckFormat($"prefix {placeholder} suffix"));
+        }
+
+        [TestMethod]
+        public void CheckFormatIsFalseWhenNoPlaceholderIsPresent()
+        {
+            Assert.IsFalse(Popstation.Popstation.CheckFormat("just a plain name"));
+        }
+
+        [TestMethod]
+        public void CheckResourceFormatRecognizesResourcePlaceholder()
+        {
+            Assert.IsTrue(Popstation.Popstation.CheckResourceFormat("%RESOURCE%"));
+            Assert.IsFalse(Popstation.Popstation.CheckResourceFormat("no placeholders here"));
+        }
+
+        [TestMethod]
+        public void GetFilenameReplacesAllBasePlaceholders()
+        {
+            var result = Popstation.Popstation.GetFilename(
+                "%TITLE% (%REGION%) [%GAMEID%] {%MAINTITLE%|%MAINGAMEID%} %FILENAME%",
+                "source.iso",
+                "SLUS-00001",
+                "SLUS00001",
+                "My Game",
+                "My Game Main",
+                "NTSC-U");
+
+            Assert.AreEqual("My Game (NTSC-U) [SLUS-00001] {My Game Main|SLUS00001} source", result);
+        }
+
+        [TestMethod]
+        public void GetFilenamePlaceholdersAreCaseInsensitive()
+        {
+            var result = Popstation.Popstation.GetFilename(
+                "%title% - %gameid%",
+                @"source.iso",
+                "SLUS-00001",
+                "SLUS00001",
+                "My Game",
+                "My Game Main",
+                "NTSC-U");
+
+            Assert.AreEqual("My Game - SLUS-00001", result);
+        }
+
+        [TestMethod]
+        public void GetResourceFilenameAlsoReplacesResourceAndExtPlaceholders()
+        {
+            var result = Popstation.Popstation.GetResourceFilename(
+                "%FILENAME%\\%RESOURCE%.%EXT%",
+                @"source.iso",
+                "SLUS-00001",
+                "SLUS00001",
+                "My Game",
+                "My Game Main",
+                "NTSC-U",
+                ResourceType.ICON0,
+                "png");
+
+            Assert.AreEqual("source\\ICON0.png", result);
+        }
+
+        [TestMethod]
+        public void GetResourceFolderDoesNotReplaceResourceOrExtPlaceholders()
+        {
+            // %RESOURCE% and %EXT% are only defined for GetResourceFilename, not for
+            // the plain filename/folder helpers - this pins that (pre-existing) behavior.
+            var result = Popstation.Popstation.GetResourceFolder(
+                "%FILENAME%\\%RESOURCE%",
+                @"source.iso",
+                "SLUS-00001",
+                "SLUS00001",
+                "My Game",
+                "My Game Main",
+                "NTSC-U");
+
+            Assert.AreEqual("source\\%RESOURCE%", result);
+        }
+    }
+}

--- a/PSXPackager.Tests/ProcessingMergeBinsTests.cs
+++ b/PSXPackager.Tests/ProcessingMergeBinsTests.cs
@@ -1,0 +1,202 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Popstation;
+using PSXPackager.Common;
+using PSXPackager.Common.Cue;
+
+namespace UnitTestProject
+{
+    [TestClass]
+    public class ProcessingMergeBinsTests
+    {
+        private const int SectorSize = 2352;
+
+        private string _tempDir = string.Empty;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            Directory.CreateDirectory(_tempDir);
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            if (Directory.Exists(_tempDir))
+            {
+                Directory.Delete(_tempDir, true);
+            }
+        }
+
+        private string CreateBinFile(string name, byte fill, int sectorCount)
+        {
+            var path = Path.Combine(_tempDir, name);
+            var bytes = Enumerable.Repeat(fill, SectorSize * sectorCount).ToArray();
+            File.WriteAllBytes(path, bytes);
+            return path;
+        }
+
+        [TestMethod]
+        public void MergeBinsConcatenatesSourceBinContentInOrder()
+        {
+            CreateBinFile("track1.bin", 0xAA, sectorCount: 2);
+            CreateBinFile("track2.bin", 0xBB, sectorCount: 1);
+
+            var unmergedCue = new CueFile { Path = Path.Combine(_tempDir, "game.cue") };
+            unmergedCue.FileEntries.Add(new CueFileEntry
+            {
+                FileName = "track1.bin",
+                FileType = FileTypes.BINARY,
+                Tracks = new List<CueTrack>
+                {
+                    new CueTrack
+                    {
+                        Number = 1,
+                        DataType = DataTypes.DATA,
+                        Indexes = new List<CueIndex> { new CueIndex { Number = 1, Position = new IndexPosition(0, 0, 0) } },
+                    },
+                },
+            });
+            unmergedCue.FileEntries.Add(new CueFileEntry
+            {
+                FileName = "track2.bin",
+                FileType = FileTypes.BINARY,
+                Tracks = new List<CueTrack>
+                {
+                    new CueTrack
+                    {
+                        Number = 2,
+                        DataType = DataTypes.AUDIO,
+                        Indexes = new List<CueIndex> { new CueIndex { Number = 1, Position = new IndexPosition(0, 0, 0) } },
+                    },
+                },
+            });
+
+            using var output = new MemoryStream();
+
+            Processing.MergeBins(output, "merged.bin", unmergedCue);
+
+            var merged = output.ToArray();
+            Assert.AreEqual(SectorSize * 3, merged.Length);
+            Assert.IsTrue(merged.Take(SectorSize * 2).All(b => b == 0xAA));
+            Assert.IsTrue(merged.Skip(SectorSize * 2).All(b => b == 0xBB));
+        }
+
+        [TestMethod]
+        public void MergeBinsReturnsSingleFileEntryWithGivenName()
+        {
+            CreateBinFile("track1.bin", 0xAA, sectorCount: 1);
+
+            var unmergedCue = new CueFile { Path = Path.Combine(_tempDir, "game.cue") };
+            unmergedCue.FileEntries.Add(new CueFileEntry
+            {
+                FileName = "track1.bin",
+                FileType = FileTypes.BINARY,
+                Tracks = new List<CueTrack>
+                {
+                    new CueTrack
+                    {
+                        Number = 1,
+                        DataType = DataTypes.DATA,
+                        Indexes = new List<CueIndex> { new CueIndex { Number = 1, Position = new IndexPosition(0, 0, 0) } },
+                    },
+                },
+            });
+
+            using var output = new MemoryStream();
+
+            var mergedCue = Processing.MergeBins(output, "merged.bin", unmergedCue);
+
+            Assert.AreEqual(1, mergedCue.FileEntries.Count);
+            Assert.AreEqual("merged.bin", mergedCue.FileEntries[0].FileName);
+            Assert.AreEqual(FileTypes.BINARY, mergedCue.FileEntries[0].FileType);
+        }
+
+        [TestMethod]
+        public void MergeBinsOffsetsIndexesOfLaterTracksBySectorsConsumedByEarlierFiles()
+        {
+            // track1.bin is 2 sectors long, so track2's indexes must be shifted forward by 2 frames (sectors)
+            CreateBinFile("track1.bin", 0xAA, sectorCount: 2);
+            CreateBinFile("track2.bin", 0xBB, sectorCount: 1);
+
+            var unmergedCue = new CueFile { Path = Path.Combine(_tempDir, "game.cue") };
+            unmergedCue.FileEntries.Add(new CueFileEntry
+            {
+                FileName = "track1.bin",
+                FileType = FileTypes.BINARY,
+                Tracks = new List<CueTrack>
+                {
+                    new CueTrack
+                    {
+                        Number = 1,
+                        DataType = DataTypes.DATA,
+                        Indexes = new List<CueIndex> { new CueIndex { Number = 1, Position = new IndexPosition(0, 0, 0) } },
+                    },
+                },
+            });
+            unmergedCue.FileEntries.Add(new CueFileEntry
+            {
+                FileName = "track2.bin",
+                FileType = FileTypes.BINARY,
+                Tracks = new List<CueTrack>
+                {
+                    new CueTrack
+                    {
+                        Number = 2,
+                        DataType = DataTypes.AUDIO,
+                        Indexes = new List<CueIndex> { new CueIndex { Number = 1, Position = new IndexPosition(0, 0, 0) } },
+                    },
+                },
+            });
+
+            using var output = new MemoryStream();
+
+            var mergedCue = Processing.MergeBins(output, "merged.bin", unmergedCue);
+            var mergedTracks = mergedCue.FileEntries[0].Tracks;
+
+            Assert.AreEqual(2, mergedTracks.Count);
+
+            var firstTrackIndex = mergedTracks[0].Indexes[0].Position;
+            Assert.AreEqual(0, firstTrackIndex.Minutes);
+            Assert.AreEqual(0, firstTrackIndex.Seconds);
+            Assert.AreEqual(0, firstTrackIndex.Frames);
+
+            var secondTrackIndex = mergedTracks[1].Indexes[0].Position;
+            Assert.AreEqual(0, secondTrackIndex.Minutes);
+            Assert.AreEqual(0, secondTrackIndex.Seconds);
+            Assert.AreEqual(2, secondTrackIndex.Frames);
+        }
+
+        [TestMethod]
+        public void MergeBinsResolvesRelativeBinPathsAgainstTheCueDirectory()
+        {
+            // FileName in the cue is relative; MergeBins must resolve it against
+            // the directory of CueFile.Path, not the current working directory.
+            CreateBinFile("relative.bin", 0xCC, sectorCount: 1);
+
+            var unmergedCue = new CueFile { Path = Path.Combine(_tempDir, "game.cue") };
+            unmergedCue.FileEntries.Add(new CueFileEntry
+            {
+                FileName = "relative.bin",
+                FileType = FileTypes.BINARY,
+                Tracks = new List<CueTrack>
+                {
+                    new CueTrack
+                    {
+                        Number = 1,
+                        DataType = DataTypes.DATA,
+                        Indexes = new List<CueIndex> { new CueIndex { Number = 1, Position = new IndexPosition(0, 0, 0) } },
+                    },
+                },
+            });
+
+            using var output = new MemoryStream();
+
+            Processing.MergeBins(output, "merged.bin", unmergedCue);
+
+            Assert.AreEqual(SectorSize, output.Length);
+        }
+    }
+}

--- a/PSXPackager.Tests/SFOBuilderTests.cs
+++ b/PSXPackager.Tests/SFOBuilderTests.cs
@@ -1,0 +1,118 @@
+using System;
+using Popstation.Pbp;
+
+namespace UnitTestProject
+{
+    [TestClass]
+    public class SFOBuilderTests
+    {
+        [TestMethod]
+        public void BuildComputesHeaderAndTableOffsetsForGivenEntries()
+        {
+            var builder = new SFOBuilder();
+            builder.AddEntry(SFOKeys.DISC_ID, "SLUS-00001"); // 10 chars
+            builder.AddEntry(SFOKeys.TITLE, "Test Game");    // 9 chars
+
+            var sfo = builder.Build();
+
+            Assert.AreEqual(0x46535000u, sfo.Magic);
+            Assert.AreEqual(0x00000101u, sfo.Version);
+
+            // headerSize(20) + indexTableSize(2 entries * 16)
+            Assert.AreEqual(52u, sfo.KeyTableOffset);
+
+            // keyTableSize = ("DISC_ID".Length+1) + ("TITLE".Length+1) = 8 + 6 = 14, padded to a multiple of 4
+            Assert.AreEqual(2u, sfo.Padding);
+            Assert.AreEqual(68u, sfo.DataTableOffset);
+
+            // dataOffset accumulates each entry's MaxLength: DISC_ID(16) + TITLE(128)
+            Assert.AreEqual(212u, sfo.Size);
+        }
+
+        [TestMethod]
+        public void BuildAssignsIncreasingKeyAndDataOffsetsInEntryOrder()
+        {
+            var builder = new SFOBuilder();
+            builder.AddEntry(SFOKeys.DISC_ID, "SLUS-00001");
+            builder.AddEntry(SFOKeys.TITLE, "Test Game");
+
+            var sfo = builder.Build();
+
+            Assert.AreEqual(2, sfo.Entries.Count);
+
+            var discIdEntry = sfo.Entries[0];
+            Assert.AreEqual(SFOKeys.DISC_ID, discIdEntry.Key);
+            Assert.AreEqual((ushort)0, discIdEntry.KeyOffset);
+            Assert.AreEqual(0u, discIdEntry.DataOffset);
+            Assert.AreEqual(16u, discIdEntry.MaxLength);
+
+            var titleEntry = sfo.Entries[1];
+            Assert.AreEqual(SFOKeys.TITLE, titleEntry.Key);
+            Assert.AreEqual((ushort)8, titleEntry.KeyOffset); // "DISC_ID".Length + 1
+            Assert.AreEqual(16u, titleEntry.DataOffset);      // after DISC_ID's MaxLength
+            Assert.AreEqual(128u, titleEntry.MaxLength);
+        }
+
+        [TestMethod]
+        public void BuildUsesStringFormatForTextKeysAndIntFormatForNumericKeys()
+        {
+            const ushort stringType = 0x0204;
+            const ushort intType = 0x0404;
+
+            var builder = new SFOBuilder();
+            builder.AddEntry(SFOKeys.TITLE, "Test Game");
+            builder.AddEntry(SFOKeys.REGION, 1);
+
+            var sfo = builder.Build();
+
+            Assert.AreEqual(stringType, sfo.Entries[0].Format);
+            Assert.AreEqual(intType, sfo.Entries[1].Format);
+        }
+
+        [TestMethod]
+        public void BuildOmitsEntriesWithNullOrBlankStringValues()
+        {
+            var builder = new SFOBuilder();
+            builder.AddEntry(SFOKeys.DISC_ID, "SLUS-00001");
+            builder.AddEntry(SFOKeys.TITLE, "");
+            builder.AddEntry(SFOKeys.LICENSE, "   ");
+            builder.AddEntry(SFOKeys.DISC_VERSION, null);
+
+            var sfo = builder.Build();
+
+            Assert.AreEqual(1, sfo.Entries.Count);
+            Assert.AreEqual(SFOKeys.DISC_ID, sfo.Entries[0].Key);
+        }
+
+        [TestMethod]
+        public void BuildKeepsIntEntriesEvenWhenZero()
+        {
+            var builder = new SFOBuilder();
+            builder.AddEntry(SFOKeys.REGION, 0);
+
+            var sfo = builder.Build();
+
+            Assert.AreEqual(1, sfo.Entries.Count);
+            Assert.AreEqual(SFOKeys.REGION, sfo.Entries[0].Key);
+        }
+
+        [TestMethod]
+        public void BuildThrowsWhenValueExceedsMaxLengthForKey()
+        {
+            var builder = new SFOBuilder();
+            // DISC_ID has a 16-byte max length (including null terminator)
+            builder.AddEntry(SFOKeys.DISC_ID, new string('X', 20));
+
+            Assert.ThrowsException<Exception>(() => builder.Build());
+        }
+
+        [TestMethod]
+        public void BuildThrowsForUnrecognizedKey()
+        {
+            var builder = new SFOBuilder();
+            builder.AddEntry("NOT_A_REAL_KEY", "value");
+
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => builder.Build());
+        }
+    }
+}

--- a/PSXPackager.Tests/StreamExtensionsSfoTests.cs
+++ b/PSXPackager.Tests/StreamExtensionsSfoTests.cs
@@ -1,0 +1,68 @@
+using System.IO;
+using Popstation;
+using Popstation.Pbp;
+
+namespace UnitTestProject
+{
+    [TestClass]
+    public class StreamExtensionsSfoTests
+    {
+        [TestMethod]
+        public void WriteSFOThenReadSFORoundTripsStringAndIntEntries()
+        {
+            var builder = new SFOBuilder();
+            builder.AddEntry(SFOKeys.DISC_ID, "SLUS-00001");
+            builder.AddEntry(SFOKeys.BOOTABLE, 1);
+            builder.AddEntry(SFOKeys.TITLE, "My Game");
+            var sfo = builder.Build();
+
+            using var stream = new MemoryStream();
+            stream.WriteSFO(sfo);
+            stream.Position = 0;
+
+            var roundTripped = stream.ReadSFO(0);
+
+            Assert.AreEqual(sfo.Magic, roundTripped.Magic);
+            Assert.AreEqual(sfo.Version, roundTripped.Version);
+            Assert.AreEqual(sfo.KeyTableOffset, roundTripped.KeyTableOffset);
+            Assert.AreEqual(sfo.DataTableOffset, roundTripped.DataTableOffset);
+            Assert.AreEqual(3, roundTripped.Entries.Count);
+
+            var discId = roundTripped.Entries[0];
+            Assert.AreEqual(SFOKeys.DISC_ID, discId.Key);
+            Assert.AreEqual("SLUS-00001", discId.Value);
+
+            var bootable = roundTripped.Entries[1];
+            Assert.AreEqual(SFOKeys.BOOTABLE, bootable.Key);
+            Assert.AreEqual(1u, bootable.Value);
+
+            var title = roundTripped.Entries[2];
+            Assert.AreEqual(SFOKeys.TITLE, title.Key);
+            Assert.AreEqual("My Game", title.Value);
+        }
+
+        [TestMethod]
+        public void WriteSFOThenReadSFOPreservesKeyOffsetFormatAndLengthMetadata()
+        {
+            var builder = new SFOBuilder();
+            builder.AddEntry(SFOKeys.DISC_ID, "SLUS-00001");
+            builder.AddEntry(SFOKeys.TITLE, "My Game");
+            var sfo = builder.Build();
+
+            using var stream = new MemoryStream();
+            stream.WriteSFO(sfo);
+            stream.Position = 0;
+
+            var roundTripped = stream.ReadSFO(0);
+
+            for (var i = 0; i < sfo.Entries.Count; i++)
+            {
+                Assert.AreEqual(sfo.Entries[i].KeyOffset, roundTripped.Entries[i].KeyOffset);
+                Assert.AreEqual(sfo.Entries[i].Format, roundTripped.Entries[i].Format);
+                Assert.AreEqual(sfo.Entries[i].Length, roundTripped.Entries[i].Length);
+                Assert.AreEqual(sfo.Entries[i].MaxLength, roundTripped.Entries[i].MaxLength);
+                Assert.AreEqual(sfo.Entries[i].DataOffset, roundTripped.Entries[i].DataOffset);
+            }
+        }
+    }
+}

--- a/PSXPackager.Tests/TOCHelperTests.cs
+++ b/PSXPackager.Tests/TOCHelperTests.cs
@@ -1,0 +1,169 @@
+using System;
+using System.Collections.Generic;
+using PSXPackager.Common;
+using PSXPackager.Common.Cue;
+
+namespace UnitTestProject
+{
+    [TestClass]
+    public class TOCHelperTests
+    {
+        [TestMethod]
+        public void GetDataTypeAndGetTrackTypeRoundTrip()
+        {
+            Assert.AreEqual(CueTrackType.Data, TOCHelper.GetDataType(TrackTypeEnum.Data));
+            Assert.AreEqual(CueTrackType.Audio, TOCHelper.GetDataType(TrackTypeEnum.Audio));
+
+            Assert.AreEqual(TrackTypeEnum.Data, TOCHelper.GetTrackType(CueTrackType.Data));
+            Assert.AreEqual(TrackTypeEnum.Audio, TOCHelper.GetTrackType(CueTrackType.Audio));
+        }
+
+        [TestMethod]
+        public void GetTrackTypeThrowsForUnknownDataType()
+        {
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => TOCHelper.GetTrackType("BOGUS"));
+        }
+
+        [DataTestMethod]
+        [DataRow(0, 0)]
+        [DataRow(5, 0x05)]
+        [DataRow(10, 0x10)]
+        [DataRow(25, 0x25)]
+        [DataRow(99, 0x99)]
+        public void ToBinaryDecimalEncodesEachDigitAsNibble(int value, int expected)
+        {
+            Assert.AreEqual((byte)expected, TOCHelper.ToBinaryDecimal(value));
+        }
+
+        [DataTestMethod]
+        [DataRow(0x00, 0)]
+        [DataRow(0x05, 5)]
+        [DataRow(0x10, 10)]
+        [DataRow(0x25, 25)]
+        [DataRow(0x99, 99)]
+        public void FromBinaryDecimalIsInverseOfToBinaryDecimal(int packed, int expected)
+        {
+            Assert.AreEqual(expected, TOCHelper.FromBinaryDecimal((byte)packed));
+        }
+
+        [TestMethod]
+        public void PositionFromFramesZero()
+        {
+            var position = TOCHelper.PositionFromFrames(0);
+
+            Assert.AreEqual(0, position.Minutes);
+            Assert.AreEqual(0, position.Seconds);
+            Assert.AreEqual(0, position.Frames);
+        }
+
+        [TestMethod]
+        public void PositionFromFramesWithinFirstSecond()
+        {
+            var position = TOCHelper.PositionFromFrames(30);
+
+            Assert.AreEqual(0, position.Minutes);
+            Assert.AreEqual(0, position.Seconds);
+            Assert.AreEqual(30, position.Frames);
+        }
+
+        [TestMethod]
+        public void PositionFromFramesCarriesIntoSeconds()
+        {
+            // 75 frames per second
+            var position = TOCHelper.PositionFromFrames(76);
+
+            Assert.AreEqual(0, position.Minutes);
+            Assert.AreEqual(1, position.Seconds);
+            Assert.AreEqual(1, position.Frames);
+        }
+
+        [TestMethod]
+        public void PositionFromFramesCarriesIntoMinutes()
+        {
+            // 60 seconds * 75 frames + 20 extra frames
+            var position = TOCHelper.PositionFromFrames(60 * 75 + 20);
+
+            Assert.AreEqual(1, position.Minutes);
+            Assert.AreEqual(0, position.Seconds);
+            Assert.AreEqual(20, position.Frames);
+        }
+
+        [TestMethod]
+        public void TOCtoCUEProducesSingleFileEntryWithGivenName()
+        {
+            var tocEntries = new List<TOCEntry>
+            {
+                new TOCEntry { TrackNo = 1, TrackType = TrackTypeEnum.Data, Minutes = 0, Seconds = 2, Frames = 0 },
+            };
+
+            var cueFile = TOCHelper.TOCtoCUE(tocEntries, "game.bin");
+
+            Assert.AreEqual(1, cueFile.FileEntries.Count);
+            Assert.AreEqual("game.bin", cueFile.FileEntries[0].FileName);
+            Assert.AreEqual(FileTypes.BINARY, cueFile.FileEntries[0].FileType);
+        }
+
+        [TestMethod]
+        public void TOCtoCUEDataTrackHasSingleIndexAtTrackPosition()
+        {
+            var tocEntries = new List<TOCEntry>
+            {
+                new TOCEntry { TrackNo = 1, TrackType = TrackTypeEnum.Data, Minutes = 0, Seconds = 2, Frames = 0 },
+            };
+
+            var cueFile = TOCHelper.TOCtoCUE(tocEntries, "game.bin");
+            var track = cueFile.FileEntries[0].Tracks[0];
+
+            Assert.AreEqual(1, track.Number);
+            Assert.AreEqual(CueTrackType.Data, track.DataType);
+            Assert.AreEqual(1, track.Indexes.Count);
+            Assert.AreEqual(1, track.Indexes[0].Number);
+            Assert.AreEqual(0, track.Indexes[0].Position.Minutes);
+            Assert.AreEqual(2, track.Indexes[0].Position.Seconds);
+            Assert.AreEqual(0, track.Indexes[0].Position.Frames);
+        }
+
+        [TestMethod]
+        public void TOCtoCUEAudioTrackGetsTwoSecondPregapIndex()
+        {
+            var tocEntries = new List<TOCEntry>
+            {
+                new TOCEntry { TrackNo = 1, TrackType = TrackTypeEnum.Data, Minutes = 0, Seconds = 2, Frames = 0 },
+                new TOCEntry { TrackNo = 2, TrackType = TrackTypeEnum.Audio, Minutes = 3, Seconds = 0, Frames = 0 },
+            };
+
+            var cueFile = TOCHelper.TOCtoCUE(tocEntries, "game.bin");
+            var audioTrack = cueFile.FileEntries[0].Tracks[1];
+
+            Assert.AreEqual(2, audioTrack.Indexes.Count);
+
+            // INDEX 00 is the 2-second pregap before the track's actual start
+            Assert.AreEqual(0, audioTrack.Indexes[0].Number);
+            Assert.AreEqual(2, audioTrack.Indexes[0].Position.Minutes);
+            Assert.AreEqual(58, audioTrack.Indexes[0].Position.Seconds);
+            Assert.AreEqual(0, audioTrack.Indexes[0].Position.Frames);
+
+            // INDEX 01 is the track's actual start position
+            Assert.AreEqual(1, audioTrack.Indexes[1].Number);
+            Assert.AreEqual(3, audioTrack.Indexes[1].Position.Minutes);
+            Assert.AreEqual(0, audioTrack.Indexes[1].Position.Seconds);
+            Assert.AreEqual(0, audioTrack.Indexes[1].Position.Frames);
+        }
+
+        [TestMethod]
+        public void TOCtoCUELinksTracksInOrderViaNext()
+        {
+            var tocEntries = new List<TOCEntry>
+            {
+                new TOCEntry { TrackNo = 1, TrackType = TrackTypeEnum.Data, Minutes = 0, Seconds = 2, Frames = 0 },
+                new TOCEntry { TrackNo = 2, TrackType = TrackTypeEnum.Audio, Minutes = 3, Seconds = 0, Frames = 0 },
+            };
+
+            var cueFile = TOCHelper.TOCtoCUE(tocEntries, "game.bin");
+            var tracks = cueFile.FileEntries[0].Tracks;
+
+            Assert.AreSame(tracks[1], tracks[0].Next);
+            Assert.IsNull(tracks[1].Next);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add MSTest coverage for previously-untested core logic: `FileExtensionHelper`, `TOCHelper`, `CueFileReader`/`CueFileWriter` round-tripping, `M3uFileReader`, `Popstation` filename/resource-format placeholder replacement, and `Processing.MergeBins`
- Add coverage for `SFOBuilder` (PBP header/SFO offset computation), `CueExtensions` (sector/byte offset conversion), and `GameDB` (region-letter mapping, DB line parsing, lookup semantics)
- Add coverage for `PbpReader` (header-slot arithmetic, resource lookup, invalid-magic rejection) and `StreamExtensions` SFO read/write round-tripping
- Wire up `PSXPackager.Tests` with `ProjectReference`s to `Popstation` and `Popstation.Database` so their static helpers/types are testable

While writing the `GameDB` tests, two pre-existing behaviors were uncovered and pinned (not fixed, since changing them is a product decision):
- `DiscIndex` is always `1` for every row, because the `lastMainGameId` tracking variable used to detect consecutive same-game rows is never reassigned after initialization
- `DiscCount` only ends up populated when a row's `GameID` column happens to equal its `MainGameID` column, since the lookup table is keyed by `MainGameID` but queried by `GameID`

## Test plan
- [x] `dotnet build PSXPackager.sln` succeeds with 0 warnings/errors
- [x] `dotnet test PSXPackager.Tests/PSXPackager.Tests.csproj` — 127/127 passing